### PR TITLE
Extende usage for next-multilingual

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "cheap-watch": "^1.0.4",
     "colorette": "^2.0.16",
     "dot-properties": "^1.0.1",
+    "js-yaml": "^4.1.0",
     "intl-messageformat": "^9.11.3",
     "nookies": "^2.5.2",
     "resolve-accept-language": "^1.0.48"

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -334,6 +334,12 @@ export class Config {
     // Add file extension for translation files to environment variables so that it is available at build time (by Babel), without extra config.
     process.env.nextMultilingualTranslationFileExt = translationFileExt;
 
+    // Get automatic keys and properties handling from config
+    const optionKeysFromPath = (typeof options.keysFromPath === 'boolean' && options.keysFromPath) || false;
+
+    // Add automatic keys and properties handling to environment variables so that it is available at build time (by Babel), without extra config.
+    process.env.nextMultilingualOptionKeysFromPath = optionKeysFromPath;
+
     // Verify if the locale identifiers are using the right format.
     locales.forEach((locale) => {
       if (!isLocale(locale)) {

--- a/src/messages/Messages.tsx
+++ b/src/messages/Messages.tsx
@@ -65,7 +65,7 @@ export class Messages {
           this.sourceFilePath
         )} because it was not found in messages file ${highlightFilePath(this.messagesFilePath)}`
       );
-      return '';
+      return (new Message(this, key, key)).format(values);
     }
 
     return message.format(values);
@@ -93,7 +93,7 @@ export class Messages {
           this.sourceFilePath
         )} because it was not found in messages file ${highlightFilePath(this.messagesFilePath)}`
       );
-      return <></>;
+      return (new Message(this, key, key)).formatJsx(values);
     }
 
     return message.formatJsx(values);

--- a/src/messages/babel-plugin.ts
+++ b/src/messages/babel-plugin.ts
@@ -88,10 +88,12 @@ export class BabelifiedMessages {
  */
 export function getMessages(propertiesFilePath: string): KeyValueObject {
   const keyValueObject = parsePropertiesFile(propertiesFilePath);
+  const optionKeysFromPath = process.env.nextMultilingualOptionKeysFromPath;
+  const contextSegmentFromPath = optionKeysFromPath ? propertiesFilePath.split('.').slice(0,-2).join('.') : '';
   let context: string;
   const compactedKeyValueObject = {};
   for (const key in keyValueObject) {
-    const keySegments = key.split('.');
+    const keySegments = (!optionKeysFromPath) ? key.split('.') : [applicationId, contextSegmentFromPath, key];
     if (keySegments.length !== 3) {
       log.warn(
         `unable to use messages in ${highlightFilePath(
@@ -118,7 +120,7 @@ export function getMessages(propertiesFilePath: string): KeyValueObject {
 
     // Verify the key's context.
     if (context === undefined) {
-      if (!keySegmentRegExp.test(contextSegment)) {
+      if (!optionKeysFromPath && !keySegmentRegExp.test(contextSegment)) {
         log.warn(
           `unable to use messages in ${highlightFilePath(
             propertiesFilePath
@@ -143,7 +145,7 @@ export function getMessages(propertiesFilePath: string): KeyValueObject {
     }
 
     // Verify the key's identifier.
-    if (!keySegmentRegExp.test(idSegment)) {
+    if (!optionKeysFromPath && !keySegmentRegExp.test(idSegment)) {
       log.warn(
         `unable to use messages in ${highlightFilePath(
           propertiesFilePath
@@ -173,7 +175,8 @@ function getBabelifiedMessages(sourceFilePath: string): string {
   const sourceFilename = parsedSourceFile.name;
   const babelifiedMessages = new BabelifiedMessages(sourceFilePath);
 
-  const fileRegExp = new RegExp(`^${escapeRegExp(sourceFilename)}.(?<locale>[\\w-]+).properties$`);
+  const translationFileExt = process.env.nextMultilingualTranslationFileExt;
+  const fileRegExp = new RegExp(`^${escapeRegExp(sourceFilename)}\.(?<locale>[\\w-]+)\\${translationFileExt}$`);
 
   readdirSync(sourceFileDirectoryPath, { withFileTypes: true }).forEach((directoryEntry) => {
     if (directoryEntry.isFile()) {

--- a/src/messages/babel-plugin.ts
+++ b/src/messages/babel-plugin.ts
@@ -157,7 +157,9 @@ export function getMessages(propertiesFilePath: string): KeyValueObject {
     }
 
     // If validation passes, keep only the identifier part of the key to reduce file sizes.
-    compactedKeyValueObject[idSegment] = keyValueObject[key];
+    const keyValue = keyValueObject[key];
+    // DRY if optionKeysFromPath and key is already message
+    compactedKeyValueObject[idSegment] = (optionKeysFromPath && (keyValue === null || String(keyValue) === '')) ? key : keyValue;
   }
   return compactedKeyValueObject;
 }

--- a/src/messages/index.tsx
+++ b/src/messages/index.tsx
@@ -110,14 +110,15 @@ export function slugify(message: string, locale: string): string {
  */
 export function getMessagesFilePath(filesystemPath: string, locale: string): string {
   const pageFileExtension = extname(filesystemPath);
+  const translationFileExt = process.env.nextMultilingualTranslationFileExt;
 
   if (pageFileExtension) {
     // Filesystem path is a file.
-    return `${filesystemPath.replace(pageFileExtension, '')}.${normalizeLocale(locale)}.properties`;
+    return `${filesystemPath.replace(pageFileExtension, '')}.${normalizeLocale(locale)}${translationFileExt}`;
   }
 
   // Filesystem path is a directory.
-  return `${filesystemPath}/index.${normalizeLocale(locale)}.properties`;
+  return `${filesystemPath}/index.${normalizeLocale(locale)}${translationFileExt}`;
 }
 
 /**
@@ -252,7 +253,8 @@ export function handleMessages(
   const sourceBasename = sourceFilePath.split('/').pop();
   const sourceFilename = sourceBasename.split('.').slice(0, -1).join('.');
   const sourceFileDirectoryPath = sourceFilePath.split('/').slice(0, -1).join('/');
-  const messagesFilename = `${sourceFilename}.${normalizeLocale(locale)}.properties`;
+  const translationFileExt = process.env.nextMultilingualTranslationFileExt;
+  const messagesFilename = `${sourceFilename}.${normalizeLocale(locale)}${translationFileExt}`;
   const messagesFilePath = sourceFileDirectoryPath.length
     ? `${sourceFileDirectoryPath}/${messagesFilename}`
     : messagesFilename;


### PR DESCRIPTION
1. [feat: use key as message when not found](https://github.com/Avansai/next-multilingual/commit/6b928ee23dd6bc3e36b9cc7ad8db9ce5a62218e8)

If a component has a message file for the selected locale but not a key entry for the requested key, do not return just an empty string but the key. This makes sense also when using formatJsx and want to see just replacement for values.

2. [feat: allow extended options and different file types for translation…](https://github.com/Avansai/next-multilingual/commit/87d34d3ce8c805c146d183b8f9c3657214912810)

Instead only using `.properties` file types also `.json` and `.ya?ml` files are possible.

```yaml
exampleApp.component.myId: This is the text
exampleApp.component.myIdMultiline:
  This is the text over
  multiple lines handled
  by yaml
```

3. [feat: allow different parser based on translation file ext](https://github.com/Avansai/next-multilingual/commit/82c0e1cde09492c0425e851ec603093cf54c9b48)

Based on the translation file extension select the right parser for dot-properties, json, yaml.

4. [feat: allow option keys from path](https://github.com/Avansai/next-multilingual/commit/cc2880ff4b9b10ff6365ec67ab986a1ab4685c81)

Instead have to define fix structure per component (applicationId.segment.key), you may use simple key=value files also. The appId and a unique segmentContext is inserted by components filePath.

__pages/about.js__

```js
import { useMessages } from 'next-multilingual/messages';
...
  const messages = useMessages();
...
  {messages.format('about')}
  {messages.format('Who we are?')}
```

__pages/about.de-DE.yaml__

```yaml
about: Ein tolles Team!
Who we are?: Wer sind wir?
```

__next.config.js__

```js
const config = new Config('myApp', ['de-DE'], { fileExt: '.yaml', keysFromPath: true });
```

5. [feat: allow DRY if keys from path and key already defines the message](https://github.com/Avansai/next-multilingual/commit/41eeb3e2aa41c125f5708c44c59697dc196b49ce)

When using full text as keys it does not make sense (DRY) to repeat this for value in 1 to 1.

```js
  {messages.format('Who we are?')}
```

__pages/about.en-US.yaml__

```yaml
Who we are?:
```

This is handled as existing key and the value is set by key instead of an empty / null value